### PR TITLE
Turn off unnecessary / crazy strict rules

### DIFF
--- a/packages/base/lib/rules/best-practices.js
+++ b/packages/base/lib/rules/best-practices.js
@@ -32,7 +32,7 @@ module.exports = {
     'no-labels': 2,
     'no-lone-blocks': 2,
     'no-loop-func': 2,
-    'no-magic-numbers': 2,
+    'no-magic-numbers': 0,
     'no-multi-spaces': 2,
     'no-multi-str': 0,
     'no-new': 2,

--- a/packages/base/lib/rules/best-practices.js
+++ b/packages/base/lib/rules/best-practices.js
@@ -8,7 +8,7 @@ module.exports = {
     'consistent-return': 2,
     'curly': 2,
     'default-case': 2,
-    'dot-location': 2,
+    'dot-location': ['error', 'property'],
     'dot-notation': 2,
     'eqeqeq': 2,
     'guard-for-in': 0,

--- a/packages/base/lib/rules/errors.js
+++ b/packages/base/lib/rules/errors.js
@@ -16,11 +16,7 @@ module.exports = {
     'no-empty-character-class': 2,
     'no-ex-assign': 2,
     'no-extra-boolean-cast': 2,
-    'no-extra-parens': [2, 'all', {
-      nestedBinaryExpressions: false,
-      enforceForArrowConditionals: false,
-      ignoreJSX: 'all',
-    }],
+    'no-extra-parens': 0,
     'no-extra-semi': 2,
     'no-func-assign': 2,
     'no-inner-declarations': 2,

--- a/packages/base/lib/rules/es6.js
+++ b/packages/base/lib/rules/es6.js
@@ -1,7 +1,7 @@
 module.exports = {
   rules: {
     'arrow-body-style': 2,
-    'arrow-parens': 2,
+    'arrow-parens': 0,
     'arrow-spacing': 2,
     'constructor-super': 2,
     'generator-star-spacing': 2,

--- a/packages/base/lib/rules/node.js
+++ b/packages/base/lib/rules/node.js
@@ -1,7 +1,7 @@
 module.exports = {
   rules: {
     'callback-return': 2,
-    'global-require': 2,
+    'global-require': 0,
     'no-buffer-constructor': 2,
     'no-mixed-requires': 2,
     'no-new-require': 2,

--- a/packages/base/lib/rules/style.js
+++ b/packages/base/lib/rules/style.js
@@ -96,7 +96,11 @@ module.exports = {
     'sort-keys': 0,
     'sort-vars': 0,
     'space-before-blocks': 2,
-    'space-before-function-paren': ['error', 'never'],
+    'space-before-function-paren': ['error', {
+      "anonymous": "never",
+      "named": "never",
+      "asyncArrow": "always"
+    }],
     'space-in-parens': 2,
     'space-infix-ops': 2,
     'space-unary-ops': ['error', {

--- a/packages/base/lib/rules/style.js
+++ b/packages/base/lib/rules/style.js
@@ -86,7 +86,7 @@ module.exports = {
     'no-whitespace-before-property': 2,
     'nonblock-statement-body-position': 0,
     'object-curly-spacing': ['error', 'always'],
-    'object-property-newline': 2,
+    'object-property-newline': 0,
     'one-var': ['error', 'never'],
     'one-var-declaration-per-line': 0,
     'operator-assignment': 2,

--- a/packages/base/lib/rules/style.js
+++ b/packages/base/lib/rules/style.js
@@ -18,7 +18,7 @@ module.exports = {
     'func-names': 0,
     'func-style': 0,
     'function-call-argument-newline': 0,
-    'function-paren-newline': 2,
+    'function-paren-newline': ['error', 'consistent'],
     'id-blacklist': ['error',
       'el',
       'element',

--- a/packages/base/lib/rules/style.js
+++ b/packages/base/lib/rules/style.js
@@ -28,7 +28,12 @@ module.exports = {
       'data',
       'results',
     ],
-    'id-length': 2,
+    'id-length': ['error', {
+      exceptions: [
+        '_',
+        '$',
+      ],
+    }],
     'id-match': 0,
     'implicit-arrow-linebreak': 2,
     'indent': ['error', 2],

--- a/packages/base/lib/rules/style.js
+++ b/packages/base/lib/rules/style.js
@@ -5,7 +5,9 @@ module.exports = {
     'array-element-newline': ['error', 'consistent'],
     'block-spacing': 2,
     'brace-style': 2,
-    'camelcase': 2,
+    'camelcase': ['error', {
+      'properties': 'never',
+    }],
     'capitalized-comments': 0,
     'comma-dangle': ['error', 'only-multiline'],
     'comma-spacing': 2,

--- a/packages/base/lib/rules/variables.js
+++ b/packages/base/lib/rules/variables.js
@@ -1,6 +1,6 @@
 module.exports = {
   rules: {
-    'init-declarations': 2,
+    'init-declarations': 0,
     'no-delete-var': 2,
     'no-label-var': 2,
     'no-restricted-globals': 0,

--- a/packages/dev/lib/rules/style.js
+++ b/packages/dev/lib/rules/style.js
@@ -1,6 +1,5 @@
 module.exports = {
   rules: {
-    'capitalized-comments': 2,
     'prefer-object-spread': 2,
   },
 };

--- a/packages/student/lib/rules/best-practices.js
+++ b/packages/student/lib/rules/best-practices.js
@@ -1,7 +1,6 @@
 module.exports = {
   rules: {
     'no-extend-native': 0,
-    'no-magic-numbers': 0,
     'no-param-reassign': 1,
     'no-warning-comments': 0,
     'consistent-return': 1,

--- a/packages/student/lib/rules/es6.js
+++ b/packages/student/lib/rules/es6.js
@@ -1,6 +1,5 @@
 module.exports = {
   rules: {
-    'arrow-parens': 0,
     'constructor-super': 1,
     'no-useless-constructor': 1,
   },

--- a/packages/typescript/lib/rules/best-practices.js
+++ b/packages/typescript/lib/rules/best-practices.js
@@ -2,8 +2,5 @@ module.exports = {
   rules: {
     'no-empty-function': 0,
     '@typescript-eslint/no-empty-function': 2,
-
-    'no-magic-numbers': 0,
-    '@typescript-eslint/no-magic-numbers': 2,
   },
 };

--- a/packages/typescript/lib/rules/errors.js
+++ b/packages/typescript/lib/rules/errors.js
@@ -1,6 +1,5 @@
 module.exports = {
   rules: {
-    'no-extra-parens': 0,
-    '@typescript-eslint/no-extra-parens': 2,
+    
   },
 };


### PR DESCRIPTION
Turn off:
- "no-magic-numbers"
- "capitalized-comments"
- "init-declarations"
- "global-require" 
- "arrow-parens"
- "object-property-newline"

Adjust:
- "space-before-function-paren"
- "id-length"
- "dot-location"
- "function-paren-newline"

Published as canary on:
~~`0.2.1-alpha.10`~~
`0.3.0-alpha.11`
